### PR TITLE
SMPROD-15567: Delete scratch image option from matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        docker: ['scratch','ubi']
+        docker: ['ubi']
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     name: ${{ matrix.docker }}


### PR DESCRIPTION
Past version of build stage in grok-exporter didnt have scratch image. In the migration to new jenkins the scratch option was added by mistake.